### PR TITLE
Whistle shouldn't hide when there is an orientation change

### DIFF
--- a/Source/WhistleFactory.swift
+++ b/Source/WhistleFactory.swift
@@ -165,7 +165,6 @@ open class WhistleFactory: UIViewController {
   func orientationDidChange() {
     if whistleWindow.isKeyWindow {
       setupFrames()
-      hide()
     }
   }
     


### PR DESCRIPTION
This relates to:
https://allinmobile.atlassian.net/browse/PDI-356

When I minimise application, `func orientationDidChange()` in `WhistleFactory.swift` is called, as `NSNotification.Name.UIDeviceOrientationDidChange` is called (not sure why).

Tested on iOS 10.2 on Simulator, iOS 10.1 on the device.

The application is `Portrait` mode only.

Is there any reason that `func orientationDidChange()` includes `hides()`  - this is not the case for `ShoutFactory`, `WhisperFactory`